### PR TITLE
Fix version conflicts caused by PR#63

### DIFF
--- a/Samples/Sleep.Client/Sleep.Client.csproj
+++ b/Samples/Sleep.Client/Sleep.Client.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.6.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
     <PackageReference Include="NLog" Version="4.5.6" />
     <PackageReference Include="NLog.Mongo" Version="4.5.0.57" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/Samples/Sleep.Service/Sleep.Service.csproj
+++ b/Samples/Sleep.Service/Sleep.Service.csproj
@@ -14,7 +14,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
-    <PackageReference Include="MongoDB.Driver" Version="2.6.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
     <PackageReference Include="NLog" Version="4.5.6" />
     <PackageReference Include="NLog.Mongo" Version="4.5.0.57" />
     <PackageReference Include="System.Runtime.InteropServices.RuntimeInformation" Version="4.3.0" />

--- a/src/MongoDB.Messaging.SignalR/MongoDB.Messaging.SignalR.csproj
+++ b/src/MongoDB.Messaging.SignalR/MongoDB.Messaging.SignalR.csproj
@@ -27,7 +27,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.AspNet.SignalR.Core" Version="2.2.3" />
-    <PackageReference Include="MongoDB.Driver" Version="2.6.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
   </ItemGroup>
   <ItemGroup>

--- a/src/MongoDB.Messaging/MongoDB.Messaging.csproj
+++ b/src/MongoDB.Messaging/MongoDB.Messaging.csproj
@@ -11,7 +11,7 @@
     <PackageTags>MongoDB;Messaging</PackageTags>
     <PackageProjectUrl>https://github.com/loresoft/MongoDB.Messaging</PackageProjectUrl>
     <PackageLicenseUrl>https://raw.githubusercontent.com/loresoft/MongoDB.Messaging/master/LICENSE</PackageLicenseUrl>
-    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.0</NetStandardImplicitPackageVersion>
+    <NetStandardImplicitPackageVersion Condition=" '$(TargetFramework)' == 'netstandard1.5' ">1.6.1</NetStandardImplicitPackageVersion>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
@@ -27,7 +27,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="MongoDB.Driver" Version="2.6.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
@@ -38,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netstandard1.5' ">
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
-    <PackageReference Include="System.Threading.ThreadPool" Version="4.0.10" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
+    <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
   </ItemGroup>
 </Project>

--- a/test/MongoDB.Messaging.Tests/MongoDB.Messaging.Tests.csproj
+++ b/test/MongoDB.Messaging.Tests/MongoDB.Messaging.Tests.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.7.2" />
     <PackageReference Include="DataGenerator" Version="4.0.0.19" />
     <PackageReference Include="FluentAssertions" Version="5.3.2" />
-    <PackageReference Include="MongoDB.Driver" Version="2.6.1" />
+    <PackageReference Include="MongoDB.Driver" Version="2.12.4" />
     <PackageReference Include="NLog" Version="4.5.6" />
     <PackageReference Include="xunit" Version="2.3.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.3.1" />
@@ -29,9 +29,9 @@
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp1.0' ">
-    <PackageReference Include="System.ComponentModel" Version="4.0.1" />
-    <PackageReference Include="System.Runtime" Version="4.1.0" />
-    <PackageReference Include="System.Threading.Thread" Version="4.0.0" />
+    <PackageReference Include="System.ComponentModel" Version="4.3.0" />
+    <PackageReference Include="System.Runtime" Version="4.3.0" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
I encountered a similar dependency hell issue when bump MongoDB.Driver from 2.6.1 to 2.12.4. [(PR#63)](https://github.com/loresoft/MongoDB.Messaging/pull/63).
Hope this fix can help you.

Best regards,
sucrose